### PR TITLE
Fix: When 16 keys are used in the map, call SINGLES_KEYMAP

### DIFF
--- a/keyboard/roadkit/keymap_roadkit.c
+++ b/keyboard/roadkit/keymap_roadkit.c
@@ -2,16 +2,16 @@
 
 const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     /* 0: qerty */
-    KEYMAP(KP_7,  KP_8,   KP_9,   KP_PLUS, \
-           KP_4,  KP_5,   KP_6,   KP_MINUS, \
-           KP_1,  KP_2,   KP_3,   KP_ENTER, \
-           KP_0,  KP_DOT, FN0,    BSPC ),
+    SINGLES_KEYMAP(KP_7,  KP_8,   KP_9,   KP_PLUS, \
+                   KP_4,  KP_5,   KP_6,   KP_MINUS, \
+                   KP_1,  KP_2,   KP_3,   KP_ENTER, \
+                   KP_0,  KP_DOT, FN0,    BSPC ),
 
     /* 1: FN 1 */
-    KEYMAP(NUMLOCK,  FN1,   TRNS,   VOLU, \
-           TRNS,  UP,   TRNS,   VOLD, \
-           LEFT,  DOWN,   RIGHT,   TRNS, \
-           TRNS,  TRNS,   TRNS, TRNS ),
+    SINGLES_KEYMAP(NUMLOCK, FN1,   TRNS,   VOLU, \
+                   TRNS,    UP,   TRNS,   VOLD, \
+                   LEFT,    DOWN,   RIGHT,   TRNS, \
+                   TRNS,    TRNS,   TRNS, TRNS ),
 
 };
 


### PR DESCRIPTION
Currently, the KEYMAP macro in keymap_common.h takes 13 parameters.
This is the macro to use when a user is using the 13 switch layout
of the roadkit. However, when a user is using a 16 switch layout,
the macro called SINGLES_KEYMAP should be used.