### PR TITLE
Fix fn_actions in low-writer arrow keymap

### DIFF
--- a/keyboard/low-writer/keymap_tv44_arrow.c
+++ b/keyboard/low-writer/keymap_tv44_arrow.c
@@ -26,7 +26,7 @@ const uint8_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
                  TRNS, LSFT,     B,  SPC,       C,      TRNS, TRNS, TRNS, TRNS),
 };
 
-const uint16_t PROGMEM fn_actions[] = {
+const action_t PROGMEM fn_actions[] = {
     [0]  = ACTION_LAYER_MOMENTARY(1),
     [1]  = ACTION_LAYER_MOMENTARY(2),
     [2]  = ACTION_LAYER_TOGGLE(3),


### PR DESCRIPTION
I mentioned this via email, but figured I could take the 5 min to finish it up.